### PR TITLE
Fix Incorrect Dict Keying, add ability to add plugin via instance

### DIFF
--- a/pteranodon/plugins/plugin_manager.py
+++ b/pteranodon/plugins/plugin_manager.py
@@ -60,7 +60,7 @@ class PluginManager:
             new_plugin_obj = new_plugin(self._system, self._loop, self._logger, self._base_plugins, self._custom_args)
 
         if new_plugin_obj.name in self._custom_plugins:
-            print("Could not add plugin with name \"{}\"! A plugin with that name already exists!".format(new_plugin_obj.name))
+            self._logger.error("Could not add plugin with name \"{}\"! A plugin with that name already exists!".format(new_plugin_obj.name))
             return
 
         self._custom_plugins[new_plugin.name] = new_plugin


### PR DESCRIPTION
* Fixes issue #31 while clarifying the two possible types to the `PluginManager.add_plugin` method. 
* Can now add a plugin using a plugin instance instead of just a class type.
* Method now checks if the plugin already exists. _This method should possibly throw an error. Please leave a comment if that seems correct._