### PR TITLE
Power plugin was preventing other OSs from running

### DIFF
--- a/pteranodon/plugins/extension_plugins/power/power.py
+++ b/pteranodon/plugins/extension_plugins/power/power.py
@@ -54,16 +54,22 @@ class Power(AbstractExtensionPlugin):
             self._tegra_instantiated = True
         except SubprocessError:
             pass
+        except FileNotFoundError:
+            # Tegrastats is not installed or supported on these platforms
+            pass
 
         self._rpi_instantiated = False
         try:
             self._rpi = RPi()
             self._rpi_instantiated = True
-        except SubprocessError:
+        except NotImplementedError:
+            # Don't shut down drone if RPI not implemented
             pass
 
         self._window: Deque[telemetry.Battery] = deque(maxlen=self._window_size)
         self._telemetry.register_battery_handler(self._battery_handler)
+
+        self._ready = self._tegra_instantiated or self._rpi_instantiated
 
     def _battery_handler(self, battery: telemetry.Battery):
         self._window.append((battery, time.time()))

--- a/pteranodon/plugins/extension_plugins/power/rpi.py
+++ b/pteranodon/plugins/extension_plugins/power/rpi.py
@@ -8,9 +8,9 @@ class RPi:
 
     def __init__(self):
         try:
-            raise subprocess.SubprocessError
-        except subprocess.SubprocessError:
-            raise RuntimeError("RPi not implemented yet")  # pylint: disable=[W0707]
+            raise NotImplementedError
+        except NotImplementedError:
+            raise NotImplementedError("RPi not implemented yet")
 
     @staticmethod
     def get_current_power() -> int:

--- a/pteranodon/plugins/extension_plugins/power/rpi.py
+++ b/pteranodon/plugins/extension_plugins/power/rpi.py
@@ -1,6 +1,3 @@
-import subprocess
-
-
 class RPi:
     """
     A class for acquring the power usage of a Raspberry pi 4
@@ -9,8 +6,8 @@ class RPi:
     def __init__(self):
         try:
             raise NotImplementedError
-        except NotImplementedError:
-            raise NotImplementedError("RPi not implemented yet")
+        except NotImplementedError as err:
+            raise NotImplementedError("RPi not implemented yet") from err
 
     @staticmethod
     def get_current_power() -> int:

--- a/pteranodon/plugins/extension_plugins/power/tegra.py
+++ b/pteranodon/plugins/extension_plugins/power/tegra.py
@@ -11,10 +11,10 @@ class Tegra:
             subprocess.run(["tegrastats", "--interval", str(interval)], check=True)
         except subprocess.SubprocessError:
             raise RuntimeError("Tegra could not be started")  # pylint: disable=[W0707]
-        except FileNotFoundError:
+        except FileNotFoundError as err:
             raise FileNotFoundError(
                 "Tegra could not be started: Tegrastats not installed"
-            )
+            ) from err
 
     @staticmethod
     def battery_5vrail_power() -> int:

--- a/pteranodon/plugins/extension_plugins/power/tegra.py
+++ b/pteranodon/plugins/extension_plugins/power/tegra.py
@@ -8,9 +8,13 @@ class Tegra:
 
     def __init__(self, interval=60):
         try:
-            subprocess.run(["tegrastats", "--inteval", interval], check=True)
+            subprocess.run(["tegrastats", "--interval", str(interval)], check=True)
         except subprocess.SubprocessError:
             raise RuntimeError("Tegra could not be started")  # pylint: disable=[W0707]
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                "Tegra could not be started: Tegrastats not installed"
+            )
 
     @staticmethod
     def battery_5vrail_power() -> int:


### PR DESCRIPTION
If tegrastats was not installed, then the drone could not instantiate, and after that, the drone would never instantiate since the RPi raised a `RuntimeError` since it's not implemented, which was not handled.

Also changed the `_window` variable in `power.py` to be a tuple instead of just a battery throughout (remnants of old code)