### PR TITLE
Feature/#23 top level methods queue

### DIFF
--- a/pteranodon/README.md
+++ b/pteranodon/README.md
@@ -1,0 +1,40 @@
+# Drone
+
+## Plugins
+
+`AbstractDrone` and it's subclasses use a FIFO queue for plugin methods. This allows these methods to be executed
+in the order they are called. To allow for a delay in processing between commands in the queue, a time slice
+can be set either in the initializer or after the fact. 
+
+All plugin based commands that are called directly through the `AbstractDrone` object are added directly to the queue. 
+
+These methods include:
+
+**Base Plugins**
+- `Action.arm` &#8594; `AbstractDrone.arm` 
+- `Action.disarm` &#8594; `AbstractDrone.disarm`
+- `Action.hold` &#8594; `AbstractDrone.hold` 
+- `Action.land` &#8594; `AbstractDrone.land` 
+- `Action.return_to_launch` &#8594; `AbstractDrone.return_to_launch` 
+- `Action.set_maximum_speed` &#8594; `AbstractDrone.set_maximum_speed`
+- `Action.set_return_to_launch_altitude` &#8594; `AbstractDrone.set_return_to_launch_altitude`
+- `Action.set_takeoff_altitude` &#8594; `AbstractDrone.set_takeoff_altitude`
+- `Action.shutdown` &#8594; `AbstractDrone.shutdown`
+- `Action.takeoff` &#8594; `AbstractDrone.takeoff`
+- `Action.land` &#8594; `AbstractDrone.land`
+
+**Extension Plugins**
+- `Relative.maneuver_to` &#8594; `Relative.maneuver_to`
+- `Relative.create_geofence` &#8594; `Relative.create_geofence`
+
+Other plugin methods can be manually added to the queue using the `AbstractDrone.put` method. Methods can be directly
+passed in as the `Callable` type for simple control, or can be wrapped in the `AbstractDrone.Command` dataclass for more
+complex control.
+
+The `AbstractDrone.Command` dataclass allows for the optional addition of many needed features such as,
+- Setting a priority of this command. By default, all commands have a priority of 1 with lower priority commands being run last.
+Commands are sorted by priority when a command has been executed or when a command is added to the queue via the `put` command.
+- The option to preempt the scheduling of the queue and add this command to the front of the queue, setting it to be next for execution.
+If `preempt` is `True`, the priority is overridden to be equal to 1. 
+- The ability to set a "handler" which is executed, not when the command has finished, but instead when it has been processed
+from the queue.

--- a/pteranodon/README.md
+++ b/pteranodon/README.md
@@ -15,15 +15,23 @@ These methods include:
 **Base Plugins**
 - `Action.arm` &#8594; `AbstractDrone.arm` 
 - `Action.disarm` &#8594; `AbstractDrone.disarm`
+- `Action.do_orbit` &#8594; `AbstractDrone.do_orbit`
+- `Action.goto_location` &#8594; `AbstractDrone.goto_location`
 - `Action.hold` &#8594; `AbstractDrone.hold` 
+- `Action.kill` &#8594; `AbstractDrone.kill`
 - `Action.land` &#8594; `AbstractDrone.land` 
+- `Action.reboot` &#8594; `AbstractDrone.reboot`
 - `Action.return_to_launch` &#8594; `AbstractDrone.return_to_launch` 
+- `Action.set_actuator` &#8594; `AbstractDrone.set_actuator`
+- `Action.set_current_speed` &#8594; `AbstractDrone.set_current_speed`
 - `Action.set_maximum_speed` &#8594; `AbstractDrone.set_maximum_speed`
 - `Action.set_return_to_launch_altitude` &#8594; `AbstractDrone.set_return_to_launch_altitude`
 - `Action.set_takeoff_altitude` &#8594; `AbstractDrone.set_takeoff_altitude`
 - `Action.shutdown` &#8594; `AbstractDrone.shutdown`
 - `Action.takeoff` &#8594; `AbstractDrone.takeoff`
-- `Action.land` &#8594; `AbstractDrone.land`
+- `Action.terminate` &#8594; `AbstractDrone.terminate`
+- `Action.transition_to_fixedwing` &#8594; `AbstractDrone.transition_to_fixedwing`
+- `Action.transition_to_multicopter` &#8594; `AbstractDrone.transition_to_multicopter`
 
 **Extension Plugins**
 - `Relative.maneuver_to` &#8594; `AbstractDrone.maneuver_to`

--- a/pteranodon/README.md
+++ b/pteranodon/README.md
@@ -6,7 +6,9 @@
 in the order they are called. To allow for a delay in processing between commands in the queue, a time slice
 can be set either in the initializer or after the fact. 
 
-All plugin based commands that are called directly through the `AbstractDrone` object are added directly to the queue. 
+All plugin based commands that are called directly through the `AbstractDrone` object are added directly to the queue.
+Methods are wrapped and pushed to the queue inside `AbstractDrone` for commands which under typical circumstances should
+be run in a specific order. All other methods can be added to the queue or called directly.
 
 These methods include:
 
@@ -24,8 +26,8 @@ These methods include:
 - `Action.land` &#8594; `AbstractDrone.land`
 
 **Extension Plugins**
-- `Relative.maneuver_to` &#8594; `Relative.maneuver_to`
-- `Relative.create_geofence` &#8594; `Relative.create_geofence`
+- `Relative.maneuver_to` &#8594; `AbstractDrone.maneuver_to`
+- `Relative.create_geofence` &#8594; `AbstractDrone.create_geofence`
 
 Other plugin methods can be manually added to the queue using the `AbstractDrone.put` method. Methods can be directly
 passed in as the `Callable` type for simple control, or can be wrapped in the `AbstractDrone.Command` dataclass for more

--- a/pteranodon/README.md
+++ b/pteranodon/README.md
@@ -12,7 +12,9 @@ be run in a specific order. All other methods can be added to the queue or calle
 
 These methods include:
 
-**Base Plugins**
+### Base Plugins
+
+**Action**
 - `Action.arm` &#8594; `AbstractDrone.arm` 
 - `Action.disarm` &#8594; `AbstractDrone.disarm`
 - `Action.do_orbit` &#8594; `AbstractDrone.do_orbit`
@@ -33,7 +35,19 @@ These methods include:
 - `Action.transition_to_fixedwing` &#8594; `AbstractDrone.transition_to_fixedwing`
 - `Action.transition_to_multicopter` &#8594; `AbstractDrone.transition_to_multicopter`
 
-**Extension Plugins**
+**Offboard**
+- `Offboard.set_acceleration_ned` &#8594; `AbstractDrone.set_acceleration_ned`
+- `Offboard.set_actuator_control` &#8594; `AbstractDrone.set_actuator_control`
+- `Offboard.set_attitude` &#8594; `AbstractDrone.set_attitude`
+- `Offboard.set_attitude_rate` &#8594; `AbstractDrone.set_attitude_rate`
+- `Offboard.set_position_global` &#8594; `AbstractDrone.set_position_global`
+- `Offboard.set_position_ned` &#8594; `AbstractDrone.set_position_ned`
+- `Offboard.set_position_velocity_ned` &#8594; `AbstractDrone.set_position_velocity_ned`
+- `Offboard.set_velocity_body` &#8594; `AbstractDrone.set_velocity_body`
+- `Offboard.set_velocity_ned` &#8594; `AbstractDrone.set_velocity_ned`
+- `Offboard.offboard_hold` &#8594; `AbstractDrone.offboard_hold`
+
+### Extension Plugins
 - `Relative.maneuver_to` &#8594; `AbstractDrone.maneuver_to`
 - `Relative.create_geofence` &#8594; `AbstractDrone.create_geofence`
 

--- a/pteranodon/abstract_drone.py
+++ b/pteranodon/abstract_drone.py
@@ -764,6 +764,9 @@ class AbstractDrone(ABC):
         else:
             command_obj = obj
 
+        if command_obj.preempt:
+            command_obj.priority = 1
+
         self._logger.info(f"User called: {command_obj}, putting call in queue")
         if command_obj.preempt:
             self._queue.appendleft((command_obj, args, kwargs))

--- a/pteranodon/abstract_drone.py
+++ b/pteranodon/abstract_drone.py
@@ -776,7 +776,9 @@ class AbstractDrone(ABC):
     ##################################################
     # TODO, implement the flag for put in these methods
 
-    # START PLUGIN QUEUE WRAPPED METHODS
+# START PLUGIN QUEUE WRAPPED METHODS
+
+    # START ACTION
 
     def arm(self) -> None:
         """
@@ -979,6 +981,105 @@ class AbstractDrone(ABC):
         """
         self.put(self.action.transition_to_multicopter)
 
+    # END ACTION
+
+    # START OFFBOARD
+
+    def set_acceleration_ned(self, accel_ned: offboard.AccelerationNed) -> None:
+        """
+        Set the acceleration in NED coordinates
+
+        :param accel_ned: The NED coordinates describing accelerating
+        :type accel_ned: offboard.AccelerationNed
+        """
+        self.put(self.offboard.set_acceleration_ned, accel_ned)
+
+    def set_actuator_control(self, act_ctrl: offboard.ActuatorControl) -> None:
+        """
+        Set direct actuator control values to groups #0 and #1
+
+        :param act_ctrl: Actuator control values
+        :type act_ctrl: offboard.ActuatorControl
+        """
+        self.put(self.offboard.set_actuator_control, act_ctrl)
+
+    def set_attitude(self, attitude: offboard.Attitude) -> None:
+        """
+        Set the attitude in terms of roll, pitch in degrees with thrust
+
+        :param attitude: Attitude role, pitch and yaw with trust
+        :type attitude: offboard.Attitude
+        """
+        self.put(self.offboard.set_attitude, attitude)
+
+    def set_attitude_rate(self, attitude_rate: offboard.AttitudeRate) -> None:
+        """
+        Set the attitude in terms of roll, pitch and yaw alog with thrust
+
+        :param attitude_rate: Attitude rate roll, pitch and yaw angular rate along with thrust
+        :type attitude_rate: offboard.AttitudeRate
+        """
+        self.put(self.offboard.set_attitude_rate, attitude_rate)
+
+    def set_position_global(self, pos_global: offboard.PositionGlobalYaw) -> None:
+        """
+        set the position in Global coordinates (latitude, longitude, altitude) and yaw
+
+        :param pos_global: Position and yaw
+        :type pos_global: offboard.PositionGlobalYaw
+        """
+        self.put(self.offboard.set_position_global, pos_global)
+
+    def set_position_ned(self, pos_ned: offboard.PositionNedYaw) -> None:
+        """
+        Set the position in Ned coordinates and yaw
+
+        :param pos_ned: Position and yaw
+        :type pos_ned: offboard.PositionNedYaw
+        """
+        self.put(self.offboard.set_position_ned, pos_ned)
+
+    def set_position_velocity_ned(
+        self, pos: offboard.PositionNedYaw, vel: offboard.VelocityNedYaw
+    ) -> None:
+        """
+        Set the position NED coordinates, with the velocity to be used as feed-forward.
+
+        :param pos: Position and yaw
+        :type pos: offboard.PositionNedYaw
+        :param vel: Velocity and yaw
+        :type vel: offboard.VelocityNedYaw
+        """
+        self.put(self.offboard.set_position_velocity_ned, pos, vel)
+
+    def set_velocity_body(self, vel_body: offboard.VelocityBodyYawspeed) -> None:
+        """
+        Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft
+
+        :param vel_body: Velocity and yaw angular rate
+        :type vel_body: offboard.VelocityBodyYawspeed
+        """
+        self.put(self.offboard.set_velocity_body, vel_body)
+
+    def set_velocity_ned(self, vel_ned: offboard.VelocityNedYaw) -> None:
+        """
+        Set the velocity in NED coordinates and yaw. Not available for fixed-wing aircraft.
+
+        :param vel_ned: Velocity and yaw
+        :type vel_ned: offboard.VelocityNedYaw
+        """
+        self.put(self.offboard.set_velocity_ned, vel_ned)
+
+    def offboard_hold(self) -> None:
+        """
+        Hold until the drone is at the altitude defined by set_attitude
+        """
+        self.put(self.offboard.hold)
+
+    # END OFFBOARD
+
+    # START EXTENSION PLUGINS
+
     def maneuver_to(
         self,
         front: float,
@@ -1013,5 +1114,8 @@ class AbstractDrone(ABC):
         """
         self.put(self.relative.create_geofence, distance)
 
+    # END EXTENSION PLUGINS
 
 # END PLUGIN QUEUE WRAPPED METHODS
+
+# pylint: disable=too-many-lines

--- a/pteranodon/abstract_drone.py
+++ b/pteranodon/abstract_drone.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 
 from mavsdk import System
 from mavsdk.offboard import OffboardError
-from mavsdk.action import ActionError
+from mavsdk.action import ActionError, OrbitYawBehavior
 
 
 try:
@@ -778,8 +778,6 @@ class AbstractDrone(ABC):
 
     # START PLUGIN QUEUE WRAPPED METHODS
 
-    from mavsdk import action
-
     def arm(self) -> None:
         """
         Arms the drone.
@@ -794,37 +792,37 @@ class AbstractDrone(ABC):
 
     def do_orbit(
         self,
-        radius_m: float,
-        velocity_ms: float,
-        yaw_behavior: action.OrbitYawBehavior,
+        radius: float,
+        velocity: float,
+        yaw_behavior: OrbitYawBehavior,
         latitude_deg: float,
         longitude_deg: float,
-        absolute_altitude_m: float,
+        absolute_altitude: float,
     ) -> None:
         """
         Send command do orbit to the drone.
 
-        :param radius_m: Radius of circle (in meters)
-        :type radius_m:  float
-        :param velocity_ms: Tangential velocity (in m/s)
-        :type velocity_ms: float
+        :param radius: Radius of circle (in meters)
+        :type radius:  float
+        :param velocity: Tangential velocity (in m/s)
+        :type velocity: float
         :param yaw_behavior: Yaw behavior of vehicle (ORBIT_YAW_BEHAVIOUR)
         :type yaw_behavior: mavsdk.action.OrbitYawBehavior
         :param latitude_deg: Center point latitude in degrees. NAN: use current latitude for center
         :type latitude_deg: float
         :param longitude_deg: Center point longitude in degrees. NAN: use current longitude for center
         :type longitude_deg: float
-        :param absolute_altitude_m: Center point altitude in meters. NAN: use current altitude for center
-        :type absolute_altitude_m: float
+        :param absolute_altitude: Center point altitude in meters. NAN: use current altitude for center
+        :type absolute_altitude: float
         """
         self.put(
             self.action.do_orbit,
-            radius_m,
-            velocity_ms,
+            radius,
+            velocity,
             yaw_behavior,
             latitude_deg,
             longitude_deg,
-            absolute_altitude_m,
+            absolute_altitude,
         )
 
     def goto_location(

--- a/pteranodon/abstract_drone.py
+++ b/pteranodon/abstract_drone.py
@@ -14,7 +14,17 @@ import functools
 from dataclasses import dataclass
 
 from mavsdk import System
-from mavsdk.offboard import OffboardError
+from mavsdk.offboard import (
+    OffboardError,
+    AccelerationNed,
+    ActuatorControl,
+    Attitude,
+    AttitudeRate,
+    PositionGlobalYaw,
+    PositionNedYaw,
+    VelocityBodyYawspeed,
+    VelocityNedYaw,
+)
 from mavsdk.action import ActionError, OrbitYawBehavior
 
 
@@ -776,7 +786,7 @@ class AbstractDrone(ABC):
     ##################################################
     # TODO, implement the flag for put in these methods
 
-# START PLUGIN QUEUE WRAPPED METHODS
+    # START PLUGIN QUEUE WRAPPED METHODS
 
     # START ACTION
 
@@ -985,88 +995,88 @@ class AbstractDrone(ABC):
 
     # START OFFBOARD
 
-    def set_acceleration_ned(self, accel_ned: offboard.AccelerationNed) -> None:
+    def set_acceleration_ned(self, accel_ned: AccelerationNed) -> None:
         """
         Set the acceleration in NED coordinates
 
         :param accel_ned: The NED coordinates describing accelerating
-        :type accel_ned: offboard.AccelerationNed
+        :type accel_ned: mavsdk.offboard.AccelerationNed
         """
         self.put(self.offboard.set_acceleration_ned, accel_ned)
 
-    def set_actuator_control(self, act_ctrl: offboard.ActuatorControl) -> None:
+    def set_actuator_control(self, act_ctrl: ActuatorControl) -> None:
         """
         Set direct actuator control values to groups #0 and #1
 
         :param act_ctrl: Actuator control values
-        :type act_ctrl: offboard.ActuatorControl
+        :type act_ctrl: mavsdk.offboard.ActuatorControl
         """
         self.put(self.offboard.set_actuator_control, act_ctrl)
 
-    def set_attitude(self, attitude: offboard.Attitude) -> None:
+    def set_attitude(self, attitude: Attitude) -> None:
         """
         Set the attitude in terms of roll, pitch in degrees with thrust
 
         :param attitude: Attitude role, pitch and yaw with trust
-        :type attitude: offboard.Attitude
+        :type attitude: mavsdk.offboard.Attitude
         """
         self.put(self.offboard.set_attitude, attitude)
 
-    def set_attitude_rate(self, attitude_rate: offboard.AttitudeRate) -> None:
+    def set_attitude_rate(self, attitude_rate: AttitudeRate) -> None:
         """
         Set the attitude in terms of roll, pitch and yaw alog with thrust
 
         :param attitude_rate: Attitude rate roll, pitch and yaw angular rate along with thrust
-        :type attitude_rate: offboard.AttitudeRate
+        :type attitude_rate: mavsdk.offboard.AttitudeRate
         """
         self.put(self.offboard.set_attitude_rate, attitude_rate)
 
-    def set_position_global(self, pos_global: offboard.PositionGlobalYaw) -> None:
+    def set_position_global(self, pos_global: PositionGlobalYaw) -> None:
         """
         set the position in Global coordinates (latitude, longitude, altitude) and yaw
 
         :param pos_global: Position and yaw
-        :type pos_global: offboard.PositionGlobalYaw
+        :type pos_global: mavsdk.offboard.PositionGlobalYaw
         """
         self.put(self.offboard.set_position_global, pos_global)
 
-    def set_position_ned(self, pos_ned: offboard.PositionNedYaw) -> None:
+    def set_position_ned(self, pos_ned: PositionNedYaw) -> None:
         """
         Set the position in Ned coordinates and yaw
 
         :param pos_ned: Position and yaw
-        :type pos_ned: offboard.PositionNedYaw
+        :type pos_ned: mavsdk.offboard.PositionNedYaw
         """
         self.put(self.offboard.set_position_ned, pos_ned)
 
     def set_position_velocity_ned(
-        self, pos: offboard.PositionNedYaw, vel: offboard.VelocityNedYaw
+        self, pos: PositionNedYaw, vel: VelocityNedYaw
     ) -> None:
         """
         Set the position NED coordinates, with the velocity to be used as feed-forward.
 
         :param pos: Position and yaw
-        :type pos: offboard.PositionNedYaw
+        :type pos: mavsdk.offboard.PositionNedYaw
         :param vel: Velocity and yaw
-        :type vel: offboard.VelocityNedYaw
+        :type vel: mavsdk.offboard.VelocityNedYaw
         """
         self.put(self.offboard.set_position_velocity_ned, pos, vel)
 
-    def set_velocity_body(self, vel_body: offboard.VelocityBodyYawspeed) -> None:
+    def set_velocity_body(self, vel_body: VelocityBodyYawspeed) -> None:
         """
         Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft
 
         :param vel_body: Velocity and yaw angular rate
-        :type vel_body: offboard.VelocityBodyYawspeed
+        :type vel_body: mavsdk.offboard.VelocityBodyYawspeed
         """
         self.put(self.offboard.set_velocity_body, vel_body)
 
-    def set_velocity_ned(self, vel_ned: offboard.VelocityNedYaw) -> None:
+    def set_velocity_ned(self, vel_ned: VelocityNedYaw) -> None:
         """
         Set the velocity in NED coordinates and yaw. Not available for fixed-wing aircraft.
 
         :param vel_ned: Velocity and yaw
-        :type vel_ned: offboard.VelocityNedYaw
+        :type vel_ned: mavsdk.offboard.VelocityNedYaw
         """
         self.put(self.offboard.set_velocity_ned, vel_ned)
 
@@ -1115,6 +1125,7 @@ class AbstractDrone(ABC):
         self.put(self.relative.create_geofence, distance)
 
     # END EXTENSION PLUGINS
+
 
 # END PLUGIN QUEUE WRAPPED METHODS
 

--- a/pteranodon/plugins/base_plugins/action.py
+++ b/pteranodon/plugins/base_plugins/action.py
@@ -36,7 +36,7 @@ class Action(AbstractBasePlugin):
         Send command to arm the drone.
         Arming a drone normally causes motors to spin at idle. Before arming take all safety precautions and stand clear
         of the drone
-        :return: None
+
         """
         self._submit_coroutine(self._system.action.arm())
 
@@ -58,20 +58,22 @@ class Action(AbstractBasePlugin):
         longitude_deg: float,
         absolute_altitude_m: float,
     ) -> None:
-
         """
         Send command do orbit to the drone.
 
-        This will run the orbit routine with the given parameters.
-        Args:
-            radius_m: Radius of circle (in meters)
-            velocity_ms: Tangential velocity (in m/s)
-            yaw_behavior: Yaw behavior of vehicle (ORBIT_YAW_BEHAVIOUR)
-            latitude_deg: Center point latitude in degrees. NAN: use current latitude for center
-            longitude_deg: Center point longitude in degrees. NAN: use current longitude for center
-            absolute_altitude_m: Center point altitude in meters. NAN: use current altitude for center
+        :param radius_m: Radius of circle (in meters)
+        :type radius_m:  float
+        :param velocity_ms: Tangential velocity (in m/s)
+        :type velocity_ms: float
+        :param yaw_behavior: Yaw behavior of vehicle (ORBIT_YAW_BEHAVIOUR)
+        :type yaw_behavior: mavsdk.action.OrbitYawBehavior
+        :param latitude_deg: Center point latitude in degrees. NAN: use current latitude for center
+        :type latitude_deg: float
+        :param longitude_deg: Center point longitude in degrees. NAN: use current longitude for center
+        :type longitude_deg: float
+        :param absolute_altitude_m: Center point altitude in meters. NAN: use current altitude for center
+        :type absolute_altitude_m: float
         """
-
         self._submit_coroutine(
             self._system.action.do_orbit(
                 radius_m,
@@ -111,19 +113,21 @@ class Action(AbstractBasePlugin):
         absolute_altitude_m: float,
         yaw: float,
     ) -> None:
-
         """
         Send command to move the vehicle to a specific global position.
 
         The latitude and longitude are given in degrees (WGS84 frame) and the altitude in meters AMSL
         (above mean sea level).
-        Args:
-            latitude_deg: Latitude (in degrees)
-            longitude_deg:  Longitude (in degrees)
-            absolute_altitude_m: Altitude AMSL (in meters)
-            yaw: Yaw angle (in degrees, frame is NED, 0 is North, positive is clockwise)
-        """
 
+        :param latitude_deg: Latitude (in degrees)
+        :type latitude_deg: float
+        :param longitude_deg: Longitude (in degrees)
+        :type longitude_deg: float
+        :param absolute_altitude_m: Altitude AMSL (in meters)
+        :type absolute_altitude_m: float
+        :param yaw: Yaw angle (in degrees, frame is NED, 0 is North, positive is clockwise)
+        :type yaw: float
+        """
         self._submit_coroutine(
             self._system.action.goto_location(
                 latitude_deg, longitude_deg, absolute_altitude_m, yaw
@@ -180,14 +184,15 @@ class Action(AbstractBasePlugin):
 
         self._submit_coroutine(self._system.action.return_to_launch())
 
-    def set_acuator(self, index: int, value: float) -> None:
+    def set_actuator(self, index: int, value: float) -> None:
         """
         Send command to set the value of an actuator.
-        Args:
-            index:
-            value:
-        """
 
+        :param index: Index of the actuator
+        :type index: int
+        :param value: Value to set
+        :type value: value
+        """
         self._submit_coroutine(self._system.action.set_actuator(index, value))
 
     def set_current_speed(self, speed_m_s: float) -> None:
@@ -196,17 +201,18 @@ class Action(AbstractBasePlugin):
 
         This will set the speed during a mission, reposition, and similar. It is ephemeral, so not stored on the drone
         and does not survive a reboot.
-        Args:
-            speed_m_s:
-        """
 
+        :param speed_m_s: The speed to set in meters per second
+        :type speed_m_s: float
+        """
         self._submit_coroutine(self._system.action.set_current_speed(speed_m_s))
 
     def set_maximum_speed(self, speed_m_s: float) -> None:
         """
         Set vehicle maximum speed (in metres/second).
-        Args:
-            speed_m_s:
+
+        :param speed_m_s: The maximum speed in meters per second
+        :type speed_m_s: float
         """
 
         self._submit_coroutine(self._system.action.set_maximum_speed(speed_m_s))
@@ -215,8 +221,9 @@ class Action(AbstractBasePlugin):
     def set_return_to_launch_altitude(self, relative_altitude_m: float) -> None:
         """
         Set the return to launch minimum return altitude (in meters).
-        Args:
-            relative_altitude_m:
+
+        :param relative_altitude_m: The relative return to launch altitude in meters
+        :type relative_altitude_m: float
         """
 
         self._submit_coroutine(
@@ -227,8 +234,9 @@ class Action(AbstractBasePlugin):
     def set_takeoff_altitude(self, relative_altitude_m: float) -> None:
         """
         Set takeoff altitude (in meters above ground).
-        Args:
-            relative_altitude_m:
+
+        :param relative_altitude_m: The relative takeoff altitude in meters
+        :type relative_altitude_m: float
         """
 
         self._submit_coroutine(

--- a/pteranodon/plugins/base_plugins/offboard.py
+++ b/pteranodon/plugins/base_plugins/offboard.py
@@ -30,49 +30,63 @@ class Offboard(AbstractBasePlugin):
     def is_active(self) -> bool:
         """
         Check if off board control is active
-        :return: boolean ; True if the off board is active, False otherwise
+
+        :return: True if the off board is active, False otherwise
+        :rtype: bool
         """
         return self._is_active
 
     def set_acceleration_ned(self, accel_ned: offboard.AccelerationNed) -> None:
         """
         Set the acceleration in NED coordinates
+
         :param accel_ned: The NED coordinates describing accelerating
+        :type accel_ned: offboard.AccelerationNed
         """
         self._submit_coroutine(self._system.offboard.set_acceleration_ned(accel_ned))
 
     def set_actuator_control(self, act_ctrl: offboard.ActuatorControl) -> None:
         """
         Set direct actuator control values to groups #0 and #1
-        :param act_ctrl: offboard.ActuatorControl ; Actuator control values
+
+        :param act_ctrl: Actuator control values
+        :type act_ctrl: offboard.ActuatorControl
         """
         self._submit_coroutine(self._system.offboard.set_actuator_control(act_ctrl))
 
     def set_attitude(self, attitude: offboard.Attitude) -> None:
         """
         Set the attitude in terms of roll, pitch in degrees with thrust
-        :param attitude: offboard.Attitude ; Attitude role, pitch and yaw with trust
+
+        :param attitude: Attitude role, pitch and yaw with trust
+        :type attitude: offboard.Attitude
         """
         self._submit_coroutine(self._system.offboard.set_attitude(attitude))
 
     def set_attitude_rate(self, attitude_rate: offboard.AttitudeRate) -> None:
         """
         Set the attitude in terms of roll, pitch and yaw alog with thrust
-        :param attitude_rate: offboard.AttitudeRate ; Attitude rate roll, pitch and yaw angular rate along with thrust
+
+        :param attitude_rate: Attitude rate roll, pitch and yaw angular rate along with thrust
+        :type attitude_rate: offboard.AttitudeRate
         """
         self._submit_coroutine(self._system.offboard.set_attitude_rate(attitude_rate))
 
     def set_position_global(self, pos_global: offboard.PositionGlobalYaw) -> None:
         """
         set the position in Global coordinates (latitude, longitude, altitude) and yaw
-        :param pos_global: offboard.PositionGlobalYaw ; Position and yaw
+
+        :param pos_global: Position and yaw
+        :type pos_global: offboard.PositionGlobalYaw
         """
         self._submit_coroutine(self._system.offboard.set_position_global(pos_global))
 
     def set_position_ned(self, pos_ned: offboard.PositionNedYaw) -> None:
         """
         Set the position in Ned coordinates and yaw
-        :param pos_ned: offboard.PositionNedYaw ; Position and yaw
+
+        :param pos_ned: Position and yaw
+        :type pos_ned: offboard.PositionNedYaw
         """
         self._submit_coroutine(self._system.offboard.set_position_ned(pos_ned))
 
@@ -80,9 +94,12 @@ class Offboard(AbstractBasePlugin):
         self, pos: offboard.PositionNedYaw, vel: offboard.VelocityNedYaw
     ) -> None:
         """
-        Set the positionin NED coordinates, with the velocity to be used as feed-forward.
-        :param pos: offboard.PositionNedYaw ; Position and yaw
-        :param vel: offboard.VelocityNedYaw ; Velocity and yaw
+        Set the position NED coordinates, with the velocity to be used as feed-forward.
+
+        :param pos: Position and yaw
+        :type pos: offboard.PositionNedYaw
+        :param vel: Velocity and yaw
+        :type vel: offboard.VelocityNedYaw
         """
         self._submit_coroutine(
             self._system.offboard.set_position_velocity_ned(pos, vel)
@@ -91,14 +108,18 @@ class Offboard(AbstractBasePlugin):
     def set_velocity_body(self, vel_body: offboard.VelocityBodyYawspeed) -> None:
         """
         Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft
-        :param vel_body: offboard.VelocityBodyYawspeed ; Velocity and yaw angular rate
+
+        :param vel_body: Velocity and yaw angular rate
+        :type vel_body: offboard.VelocityBodyYawspeed
         """
         self._submit_coroutine(self._system.offboard.set_velocity_body(vel_body))
 
     def set_velocity_ned(self, vel_ned: offboard.VelocityNedYaw) -> None:
         """
         Set the velocity in NED coordinates and yaw. Not available for fixed-wing aircraft.
-        :param vel_ned: offboard.VelocityNedYaw ; Velocity and yaw
+
+        :param vel_ned: Velocity and yaw
+        :type vel_ned: offboard.VelocityNedYaw
         """
         self._submit_coroutine(self._system.offboard.set_velocity_ned(vel_ned))
 

--- a/pteranodon/plugins/base_plugins/offboard.py
+++ b/pteranodon/plugins/base_plugins/offboard.py
@@ -38,7 +38,6 @@ class Offboard(AbstractBasePlugin):
         """
         Set the acceleration in NED coordinates
         :param accel_ned: The NED coordinates describing accelerating
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_acceleration_ned(accel_ned))
 
@@ -46,7 +45,6 @@ class Offboard(AbstractBasePlugin):
         """
         Set direct actuator control values to groups #0 and #1
         :param act_ctrl: offboard.ActuatorControl ; Actuator control values
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_actuator_control(act_ctrl))
 
@@ -54,7 +52,6 @@ class Offboard(AbstractBasePlugin):
         """
         Set the attitude in terms of roll, pitch in degrees with thrust
         :param attitude: offboard.Attitude ; Attitude role, pitch and yaw with trust
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_attitude(attitude))
 
@@ -62,7 +59,6 @@ class Offboard(AbstractBasePlugin):
         """
         Set the attitude in terms of roll, pitch and yaw alog with thrust
         :param attitude_rate: offboard.AttitudeRate ; Attitude rate roll, pitch and yaw angular rate along with thrust
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_attitude_rate(attitude_rate))
 
@@ -70,7 +66,6 @@ class Offboard(AbstractBasePlugin):
         """
         set the position in Global coordinates (latitude, longitude, altitude) and yaw
         :param pos_global: offboard.PositionGlobalYaw ; Position and yaw
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_position_global(pos_global))
 
@@ -78,7 +73,6 @@ class Offboard(AbstractBasePlugin):
         """
         Set the position in Ned coordinates and yaw
         :param pos_ned: offboard.PositionNedYaw ; Position and yaw
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_position_ned(pos_ned))
 
@@ -89,7 +83,6 @@ class Offboard(AbstractBasePlugin):
         Set the positionin NED coordinates, with the velocity to be used as feed-forward.
         :param pos: offboard.PositionNedYaw ; Position and yaw
         :param vel: offboard.VelocityNedYaw ; Velocity and yaw
-        :return: None
         """
         self._submit_coroutine(
             self._system.offboard.set_position_velocity_ned(pos, vel)
@@ -99,7 +92,6 @@ class Offboard(AbstractBasePlugin):
         """
         Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft
         :param vel_body: offboard.VelocityBodyYawspeed ; Velocity and yaw angular rate
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_velocity_body(vel_body))
 
@@ -107,14 +99,12 @@ class Offboard(AbstractBasePlugin):
         """
         Set the velocity in NED coordinates and yaw. Not available for fixed-wing aircraft.
         :param vel_ned: offboard.VelocityNedYaw ; Velocity and yaw
-        :return: None
         """
         self._submit_coroutine(self._system.offboard.set_velocity_ned(vel_ned))
 
     def start(self) -> None:
         """
         Start offboard control.
-        :return: None
         """
         self._is_active = True
         self._schedule(
@@ -128,7 +118,6 @@ class Offboard(AbstractBasePlugin):
     def stop(self) -> None:
         """
         Stop offboard control
-        :return: None
         """
         self._is_active = False
         self._submit_coroutine(self._system.offboard.stop())
@@ -136,6 +125,5 @@ class Offboard(AbstractBasePlugin):
     def hold(self) -> None:
         """
         Hold until the drone is at the altitude defined by set_attitude
-        :return: None
         """
         self.set_velocity_body(offboard.VelocityBodyYawspeed(0, 0, 0, 0))

--- a/pteranodon/plugins/extension_plugins/relative/relative.py
+++ b/pteranodon/plugins/extension_plugins/relative/relative.py
@@ -57,19 +57,22 @@ class Relative(AbstractExtensionPlugin):
         front: float,
         right: float,
         down: float,
-        on_dimensions: Tuple = (True, True, True),
+        on_dimensions: Tuple[bool, bool, bool] = (True, True, True),
         test_min: bool = False,
     ):
         """
         A movement command for moving relative to the drones current position. The front direction is aligned directly with
         the drones front as defined in the configuration.
-        :param test_min:
-        :type test_min:
+
         :param front: Relative distance in front of drone
+        :type front: float
         :param right: Relative distance to the right of drone
+        :type right: float
         :param down: Relative distance below the drone
+        :type down: float
         :param on_dimensions: A tuple of 3 boolean values. In order, they represent if the drone will move
         (front, right, down). If set to False the drone will not move in that direction
+        :type on_dimensions: Tuple[bool, bool, bool]
         """
         self._submit_coroutine(
             self._maneuver_to(front, right, down, on_dimensions, test_min)


### PR DESCRIPTION
- Added pteranodon/README.md file for documenting the drone and, most importantly, the queue system and the difference between calling them through AbstractDrone and calling them directly. Many other repos do this sort of "by directory" READMEs, so we should be good.
- I added all of the new Action methods to the AbstractDrone class directly.

PyLint fails now, though. Apparently, there is a maximum amount of lines per file in PyLint (1000) so when adding all of these methods and docs it fails. I can use `functools.partialmethod` to generate all the wrapper functions, however that won't have the autocomplete or the docs. I can also just disable the maximum # of lines requirement for this specific file. The choice is yours @justincdavis. 


Closes #23 